### PR TITLE
feat: extensions & mute extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,63 +66,6 @@ nano config.json
 pm2 start main.py --name <NAME_OF_GUILD>-BridgeBot --interpreter ./venv/bin/python --restart-delay=3000
 ```
 
-## Updating A Bridge Bot
+## More Information
 
-Coming Soon TM
-
-
-## Setting up Redis [Optional & Advanced]
-
-You can use Redis Pub/Sub to control the bridge bots programmatically from an external source.
-
-This is useful when you want to set up automation for the bridge bots without modifying the original project.
-
-Note that most users will never use this, and we will likely not provide support to you regarding this system.
-
-Prerequisites:
-- You have a redis server
-
-Add the redis server's details to the config.json file, then make sure the following are set properly:
-- `clientName` is set to something unique, such as your guild's name
-- `recieveChannel` is set to the base channel you want to recieve messages from
-  - Messages will be recieved on `{recieveChannel}:{clientName}`
-- `sendChannel` is set to the channel that the controller is recieving messages on
-
-You can then publish messages to the `{recieveChannel}:{clientName}` channel with the following format:
-```json
-{
-    "type": "request",
-    "source": "unique string identifying where the request came from, useful for multiple controllers",
-    "uuid": "unique string identifying the request, so you can get a response",
-    "endpoint": "'endpoint' of the bridge bot to call",
-    "data": {
-        "key": "value"
-    }
-}
-```
-
-The bridge bot will then respond with a message on the `sendChannel` with the following format:
-```json
-{
-    "type": "response",
-    "source": "clientName",
-    "uuid": "same uuid as request",
-    "data": {
-        "success": false,
-        "error": "error message, only present if success is false"
-    }
-}
-```
-
-If an unexpected error occurs, the bridge bot will log the error to console and respond with the following:
-```json
-{
-    "type": "response",
-    "source": "clientName",
-    "uuid": "same uuid as request",
-    "data": {
-        "error": "details"
-    }
-}
-```
-Note the lack of a `success` key, as something internal raised an exception that wasn't supposed to.
+For more information on the bot, please refer to the [documentation](https://docs.skykings.dev/bridge).

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Instructions are for Linux/Ubuntu machines
 cd ~
 
 # Install nvm & node
+
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
 source ~/.bashrc
 nvm install 19.7.0

--- a/README.md
+++ b/README.md
@@ -68,4 +68,4 @@ pm2 start main.py --name <NAME_OF_GUILD>-BridgeBot --interpreter ./venv/bin/pyth
 
 ## More Information
 
-For more information on the bot, please refer to the [documentation](https://docs.skykings.dev/bridge).
+For more information on the bot, please refer to the [documentation](https://docs.skykings.net/bridge).

--- a/core/config.py
+++ b/core/config.py
@@ -28,7 +28,7 @@ except json.JSONDecodeError as e:
 class ConfigKey:
     def __init__(self, type: type, default=...):
         self.type = type
-        self.default = (default or "") if default is not ... else ""
+        self.default = default if default is not ... else ""
         self.required = default is ...
         self.basekey = None
         self.key = None
@@ -70,7 +70,7 @@ class _ConfigObject(type):
                         raise InvalidConfig(f"Missing required key '{key}' in section '{obj.BASE_KEY}'")
                     data[key] = value.default
                 else:
-                    value.validate(data[key])
+                    data[key] = value.validate(data[key])
                 setattr(obj, key, data[key])
         elif _completed_init and keys:
             # add all keys n stuff
@@ -211,7 +211,7 @@ def generate_config():
     for section in _config_objects:
         _config[section.BASE_KEY] = {}
         for k, v in section.keys.items():
-            _config[section.BASE_KEY][k] = v.default or ""
+            _config[section.BASE_KEY][k] = v.default if v.default not in (..., None) else ""
     with open("config.json", "w") as f:
         json.dump(_config, f, indent=4)
 

--- a/core/config.py
+++ b/core/config.py
@@ -23,12 +23,14 @@ class ConfigKey:
         self.key = None
 
     def validate(self, value):
+        print(self.key, value)
         if not value:
             if self.required:
                 raise ValueError(f"Missing required key '{self.key}'")
         elif not isinstance(value, self.type):
             try:
                 value = self.type(value)
+                print(value, self.type)
             except Exception:
                 raise TypeError(f"Expected {self.type.__name__} for '{self.key}' but got {type(value).__name__}")
         return value
@@ -54,6 +56,7 @@ class _ConfigObject(type):
             else:
                 value.validate(config[key])
             setattr(obj, key, config[key])
+            print(key, config[key])
         return obj
 
 
@@ -169,6 +172,7 @@ except json.JSONDecodeError as e:
 
 validate_config(config)
 print("Config loaded successfully!")
+print(SettingsConfig.extensions)
 
 
 class ExtensionConfig(ConfigObject, base_key=""):

--- a/core/config.py
+++ b/core/config.py
@@ -1,4 +1,5 @@
 import json
+from typing import Any
 
 from core.errors import InvalidConfig
 
@@ -11,6 +12,7 @@ __all__ = (
     "ExtensionConfig",
 )
 
+_completed_init = False
 _fnf = False
 try:
     with open("config.json", "r") as file:
@@ -27,19 +29,20 @@ class ConfigKey:
         self.type = type
         self.default = (default or "") if default is not ... else ""
         self.required = default is ...
-        self._parent = None
+        self.basekey = None
         self.key = None
 
     def validate(self, value):
         if not value:
             if self.required:
-                raise ValueError(f"Missing required key '{self.key}'")
+                raise InvalidConfig(f"Missing required key '{self.key}' in section '{self.basekey}'")
             return self.default
         elif not isinstance(value, self.type):
             try:
                 value = self.type(value)
             except Exception:
-                raise TypeError(f"Expected {self.type.__name__} for '{self.key}' but got {type(value).__name__}")
+                raise TypeError(f"Expected {self.type.__name__} for '{self.key}' in section '{self.basekey}' "
+                                f"but got {type(value).__name__}")
         return value
 
 
@@ -58,14 +61,55 @@ class _ConfigObject(type):
         if data is not None:
             for key, value in keys.items():
                 value.key = key
+                value.basekey = obj.BASE_KEY
                 if key in ("keys", "BASE_KEY"):
-                    raise ValueError(f"Invalid key name '{key}'")
+                    raise InvalidConfig(f"Invalid key name '{key}' in section '{obj.BASE_KEY}'")
                 if key not in data:
+                    if value.required:
+                        raise InvalidConfig(f"Missing required key '{key}' in section '{obj.BASE_KEY}'")
                     data[key] = value.default
                 else:
                     value.validate(data[key])
                 setattr(obj, key, data[key])
+        elif _completed_init and keys:
+            # add all keys n stuff
+            config[obj.BASE_KEY] = {}
+            for k, v in keys.items():
+                config[obj.BASE_KEY][k] = v.default
+                setattr(obj, k, v.default)
+            with open("config.json", "w") as f:
+                json.dump(config, f, indent=4)
+            # check if anything is required
+            for k, v in keys.items():
+                if v.required:
+                    raise InvalidConfig(f"Missing required section '{obj.BASE_KEY}'. "
+                                        f"It has been automatically added to the config file, "
+                                        f"please update the settings.")
         return obj
+
+    @classmethod
+    def __getitem__(cls, item: str) -> Any:
+        raise NotImplementedError
+
+    @classmethod
+    def __setitem__(cls, key: str, value: Any):
+        raise NotImplementedError
+
+    @classmethod
+    def __getattr__(cls, item: str) -> Any:
+        raise NotImplementedError
+
+    @classmethod
+    def __iter__(cls) -> Any:
+        raise NotImplementedError
+
+    @classmethod
+    def get(cls, key: str) -> Any   :
+        raise NotImplementedError
+
+    @classmethod
+    def validate(cls, _config: dict) -> None:
+        raise NotImplementedError
 
 
 class ConfigObject(metaclass=_ConfigObject, base_key=""):
@@ -86,6 +130,10 @@ class ConfigObject(metaclass=_ConfigObject, base_key=""):
     @classmethod
     def __getattr__(cls, item):
         return config[cls.BASE_KEY][item]
+
+    @classmethod
+    def __setattr__(cls, key, value):
+        cls[key] = value
 
     @classmethod
     def __iter__(cls):
@@ -173,6 +221,7 @@ if _fnf:
         "No config file was found, so we generated one for you. Please set it up before continuing."
     )
 validate_config(config)
+_completed_init = True
 
 
 class ExtensionConfig(ConfigObject, base_key=""):
@@ -182,7 +231,9 @@ class ExtensionConfig(ConfigObject, base_key=""):
     Example:
     ```
     class MyExtensionConfig(ExtensionConfig, base_key="my_extension"):
-        my_key = ConfigKey(str, "default value")
+        my_key: str = ConfigKey(str, "default value")
+        my_number: int = ConfigKey(int)  # required, no default value
+        my_optional: str = ConfigKey(str, None)  # optional, with blank default (will be equivilant to "" in json)
     ```
 
     This will create a section in the config file called `my_extension` with a key `my_key`,
@@ -196,4 +247,9 @@ class ExtensionConfig(ConfigObject, base_key=""):
     # With attribute access
     MyExtensionConfig.my_key
     ```
+
+    Gimmics:
+    - A blank string (`""`) is considered a null-value during validation.
+    - If a config section is missing, it will automatically be added to the config file.
+        New keys will not be added, and will need to be entered manually.
     """

--- a/core/config.py
+++ b/core/config.py
@@ -9,6 +9,7 @@ __all__ = (
     "DiscordConfig",
     "RedisConfig",
     "SettingsConfig",
+    "ConfigKey",
     "ExtensionConfig",
 )
 

--- a/core/config.py
+++ b/core/config.py
@@ -3,88 +3,155 @@ import json
 from core.errors import InvalidConfig
 
 __all__ = (
-    "server",
-    "discord",
-    "redis",
-    "settings",
+    "ServerConfig",
+    "AccountConfig",
+    "DiscordConfig",
+    "RedisConfig",
+    "SettingsConfig",
+    "ExtensionConfig",
 )
 
-config_format = settings = {
-    "server": {
-        "host": (str, "mc.hypixel.net"),
-        "port": (int, 25565),
-    },
-    "account": {
-        "email": (str,),
-    },
-    "discord": {
-        "token": (str,),
-        "channel": (int,),
-        "officerChannel": (int, ""),
-        "commandRole": (int, ""),
-        "overrideRole": (int, ""),
-        "ownerId": (int, ""),
-        "prefix": (str, "!"),
-        "webhookURL": (str, ""),
-        "officerWebhookURL": (str, ""),
-        "debugWebhookURL": (str, ""),
-    },
-    "redis": {
-        "host": (str, ""),
-        "port": (int, ""),
-        "password": (str, ""),
-        "clientName": (str, ""),
-        "recieveChannel": (str, ""),
-        "sendChannel": (str, ""),
-    },
-    "settings": {
-        "autoaccept": (bool, False)
-    }
-}
+config = {}
 
 
-def validate_config(_config):
-    for key, value in config_format.items():
-        if _config.get(key) is None:
-            # Check if anything is required
-            for k, v in value.items():
-                if len(v) == 1:
-                    raise InvalidConfig(f"Missing required section '{key}'")
-            _config[key] = {}
-        for k, v in value.items():
-            config_val = _config[key].get(k)
-            if config_val is None or config_val == "":
-                if len(v) == 1:
-                    raise InvalidConfig(f"Missing required key '{k}' in '{key}'")
-                else:
-                    if v[1] is not None:
-                        _config[key][k] = v[1]
-            elif not isinstance(config_val, v[0]):
-                if v[0] in (str, int):
-                    try:
-                        _config[key][k] = v[0](config_val)
-                    except Exception:
-                        pass
-                    else:
-                        continue
-                raise InvalidConfig(
-                    f"Invalid type for key '{k}' in '{key}', "
-                    f"expected {v[0].__name__} but got {type(config_val).__name__}"
-                )
-    with open("config.json", "w") as f:
-        json.dump(_config, f, indent=4)
+class ConfigKey:
+    def __init__(self, type: type, default=...):
+        self.type = type
+        self.default = (default or "") if default is not ... else ""
+        self.required = default is ...
+        self._parent = None
+        self.key = None
+
+    def validate(self, value):
+        if not value:
+            if self.required:
+                raise ValueError(f"Missing required key '{self.key}'")
+        elif not isinstance(value, self.type):
+            try:
+                value = self.type(value)
+            except Exception:
+                raise TypeError(f"Expected {self.type.__name__} for '{self.key}' but got {type(value).__name__}")
+        return value
+
+
+class _ConfigObject(type):
+    def __new__(cls, name, bases, attrs, **kwargs):
+        if kwargs.get("base_key") is None:
+            raise ValueError("base_key is required in class init")
+        # get all class attrs that are ConfigKey instances
+        keys = {k: v for k, v in attrs.items() if isinstance(v, ConfigKey)}
+        # pass them off to the class init
+        obj = super().__new__(cls, name, bases, attrs)
+        obj.keys = keys
+        obj.BASE_KEY = kwargs["base_key"]
+        # validate the config
+        for key, value in keys.items():
+            value.key = key
+            if key in ("keys", "BASE_KEY"):
+                raise ValueError(f"Invalid key name '{key}'")
+            if key not in config:
+                config[key] = value.default
+            else:
+                value.validate(config[key])
+            setattr(obj, key, config[key])
+        return obj
+
+
+class ConfigObject(metaclass=_ConfigObject, base_key=""):
+    keys: dict[str, ConfigKey]
+    BASE_KEY: str
+
+    @classmethod
+    def __getitem__(cls, item):
+        return config[cls.BASE_KEY][item]
+
+    @classmethod
+    def __setitem__(cls, key, value):
+        cls.keys[key].validate(value)
+        config[cls.BASE_KEY][key] = value
+        with open("config.json", "w") as f:
+            json.dump(config, f, indent=4)
+
+    @classmethod
+    def __getattr__(cls, item):
+        return config[cls.BASE_KEY][item]
+
+    @classmethod
+    def __iter__(cls):
+        return iter(config[cls.BASE_KEY])
+
+    @classmethod
+    def get(cls, key):
+        return config[cls.BASE_KEY].get(key)
+
+    @classmethod
+    def validate(cls, _config: dict):
+        data = _config.get(cls.BASE_KEY)
+        if data is None:
+            # check if anything is required
+            for k, v in cls.keys.items():
+                if v.required:
+                    raise InvalidConfig(f"Missing required section '{cls.BASE_KEY}'")
+            _config[cls.BASE_KEY] = {}
+        for k, v in cls.keys.items():
+            config_val = data.get(k)
+            val = v.validate(config_val)
+            data[k] = val
+        with open("config.json", "w") as f:
+            json.dump(_config, f, indent=4)
+
+
+class ServerConfig(ConfigObject, base_key="server"):
+    host: str = ConfigKey(str, "mc.hypixel.net")
+    port: int = ConfigKey(int, 25565)
+
+
+class AccountConfig(ConfigObject, base_key="account"):
+    email: str = ConfigKey(str)
+
+
+class DiscordConfig(ConfigObject, base_key="discord"):
+    token: str = ConfigKey(str)
+    channel: int = ConfigKey(int)
+    officerChannel: int | None = ConfigKey(int, None)
+    commandRole: int | None = ConfigKey(int, None)
+    overrideRole: int | None = ConfigKey(int, None)
+    ownerId: int | None = ConfigKey(int, None)
+    prefix: str = ConfigKey(str, "!")
+    webhookURL: str | None = ConfigKey(str, None)
+    officerWebhookURL: str | None = ConfigKey(str, None)
+    debugWebhookURL: str | None = ConfigKey(str, None)
+
+
+class RedisConfig(ConfigObject, base_key="redis"):
+    host: str | None = ConfigKey(str, None)
+    port: int = ConfigKey(int, 6379)
+    password: str | None = ConfigKey(str, None)
+    clientName: str | None = ConfigKey(str, None)
+    recieveChannel: str | None = ConfigKey(str, None)
+    sendChannel: str | None = ConfigKey(str, None)
+
+
+class SettingsConfig(ConfigObject, base_key="settings"):
+    autoaccept: bool = ConfigKey(bool, False)
+    extensions: list[str] = ConfigKey(list, [])
+
+
+_config_objects = [ServerConfig, AccountConfig, DiscordConfig, RedisConfig, SettingsConfig]
+
+
+def validate_config(_config: dict):
+    for section in _config_objects:
+        section.validate(_config)
     return _config
 
 
 def generate_config():
     _config = {}
-    for key, value in config_format.items():
-        _config[key] = {}
-        for k, v in value.items():
-            if len(v) == 1:
-                _config[key][k] = ""
-            else:
-                _config[key][k] = v[1]
+    for section in _config_objects:
+        _config[section.BASE_KEY] = {}
+        for k, v in section.keys.items():
+            _config[section.BASE_KEY][k] = v.default or ""
     with open("config.json", "w") as f:
         json.dump(_config, f, indent=4)
 
@@ -101,29 +168,28 @@ except json.JSONDecodeError as e:
     raise InvalidConfig("The config file is not a valid JSON file.") from e
 
 validate_config(config)
+print("Config loaded successfully!")
 
 
-class ConfigObject:
-    def __init__(self, base_key: str):
-        self.__base_key = base_key
+class ExtensionConfig(ConfigObject, base_key=""):
+    """
+    This class is used for extensions to store their config data.
 
-    def __getitem__(self, item):
-        return config[self.__base_key][item]
+    Example:
+    ```
+    class MyExtensionConfig(ExtensionConfig, base_key="my_extension"):
+        my_key = ConfigKey(str, "default value")
+    ```
 
-    def __setitem__(self, key, value):
-        config[self.__base_key][key] = value
-        with open("config.json", "w") as f:
-            json.dump(config, f, indent=4)
+    This will create a section in the config file called `my_extension` with a key `my_key`,
+    as well as perform data validation automatically.
 
-    def __getattr__(self, item):
-        return config[self.__base_key][item]
+    To access the data:
+    ```
+    # As a dictionary
+    MyExtensionConfig["my_key"]
 
-    def __iter__(self):
-        return iter(self.__dict__)
-
-
-server = ConfigObject("server")
-account = ConfigObject("account")
-discord = ConfigObject("discord")
-redis = ConfigObject("redis")
-settings = ConfigObject("settings")
+    # With attribute access
+    MyExtensionConfig.my_key
+    ```
+    """

--- a/core/errors.py
+++ b/core/errors.py
@@ -1,6 +1,4 @@
 
-
-
 class BridgeBotException(Exception):
     """Base exception for BridgeBot."""
     pass
@@ -13,10 +11,11 @@ class InvalidConfig(BridgeBotException):
 
 def send_debug_message(*args, **kwargs) -> None:
     """Send a debug message to the debug channel."""
-    from core.config import discord as config
-    if not config.debugWebhookURL:
+    from core.config import DiscordConfig
+    if not DiscordConfig.debugWebhookURL:
         return
-    import requests
-    url = config.debugWebhookURL
-    requests.post(url, json={"content": " ".join(args), **kwargs})
-
+    try:
+        import requests
+    except ImportError:
+        return
+    requests.post(DiscordConfig.debugWebhookURL, json={"content": " ".join(args), **kwargs})

--- a/core/minecraft_bot.py
+++ b/core/minecraft_bot.py
@@ -41,11 +41,13 @@ class MinecraftBotManager:
             if not self._online:
                 self.send_to_discord("Bot Online")
             self._online = True
+            self.client.dispatch("minecraft_ready")
 
         @On(self.bot, "end")
         def end(this, reason):
             print(f"Mineflayer > Bot offline: {reason}")
             self.send_to_discord("Bot Offline")
+            self.client.dispatch("minecraft_disconnected")
             self._online = False
             if self.auto_restart:
                 time.sleep(120)
@@ -62,6 +64,7 @@ class MinecraftBotManager:
         @On(self.bot, "kicked")
         def kicked(this, reason, loggedIn):
             print(f"Mineflayer > Bot kicked: {reason}")
+            self.client.dispatch("minecraft_disconnected")
             if loggedIn:
                 self.send_to_discord(f"Bot kicked: {reason}")
             else:
@@ -71,6 +74,7 @@ class MinecraftBotManager:
         @On(self.bot, "error")
         def error(this, reason):
             print(reason)
+            self.client.dispatch("minecraft_error")
 
         @On(self.bot, "messagestr")
         def chat(this, message, messagePosition, jsonMsg, sender, verified):
@@ -125,7 +129,8 @@ class MinecraftBotManager:
                             "Your guild is full!" in message or \
                             "is already in your guild!" in message or \
                             ("has muted" in message and "for" in message) or \
-                            ("has unmuted" in message):
+                            "has unmuted" in message or \
+                            "You're currently guild muted" in message:
                         self.send_to_discord(message)
 
     def send_minecraft_message(self, discord, message, type):

--- a/core/minecraft_bot.py
+++ b/core/minecraft_bot.py
@@ -4,7 +4,7 @@ import time
 
 from javascript import require, On, config
 
-from core.config import server, settings, account
+from core.config import ServerConfig, SettingsConfig, AccountConfig
 
 mineflayer = require("mineflayer")
 
@@ -97,7 +97,7 @@ class MinecraftBotManager:
                     if message.startswith("Guild Name: "):
                         message_buffer.clear()
                         self.wait_response = True
-                    if message == "-----------------------------------------------------":
+                    if message == "-----------------------------------------------------" and self.wait_response:
                         self.wait_response = False
                         self.send_to_discord("\n".join(message_buffer))
                         message_buffer.clear()
@@ -123,7 +123,9 @@ class MinecraftBotManager:
                             "You cannot say the same message twice!" in message or \
                             "You don't have access to the officer chat!" in message or \
                             "Your guild is full!" in message or \
-                            "is already in your guild!" in message:
+                            "is already in your guild!" in message or \
+                            ("has muted" in message and "for" in message) or \
+                            ("has unmuted" in message):
                         self.send_to_discord(message)
 
     def send_minecraft_message(self, discord, message, type):
@@ -137,7 +139,7 @@ class MinecraftBotManager:
             self.bot.chat(message_text)
 
         if type == "invite":
-            if settings.autoaccept:
+            if SettingsConfig.autoaccept:
                 message = message.split()
                 if ("[VIP]" in message or "[VIP+]" in message or
                         "[MVP]" in message or "[MVP+]" in message or "[MVP++]" in message):
@@ -155,10 +157,10 @@ class MinecraftBotManager:
         print("Mineflayer > Creating the bot...")
         bot = mineflayer.createBot(
             {
-                "host": server.host,
-                "port": server.port,
+                "host": ServerConfig.host,
+                "port": ServerConfig.port,
                 "version": "1.8.9",
-                "username": account.email,
+                "username": AccountConfig.email,
                 "auth": "microsoft",
                 "viewDistance": "tiny",
             }

--- a/core/redis_handler.py
+++ b/core/redis_handler.py
@@ -3,7 +3,7 @@ import json
 import traceback
 import uuid
 import redis.asyncio as redis
-from core.config import redis as config
+from core.config import RedisConfig
 
 
 class RedisManager:
@@ -11,10 +11,10 @@ class RedisManager:
         self.read_task: asyncio.Task = None  # type: ignore
         self.bot = bot
         self.mineflayer_bot = mineflayer_bot
-        self.config = config
-        self.client_name = config.clientName
-        self.recieve_channel = config.recieveChannel
-        self.send_channel = config.sendChannel
+        self.config = RedisConfig
+        self.client_name = RedisConfig.clientName
+        self.recieve_channel = RedisConfig.recieveChannel
+        self.send_channel = RedisConfig.sendChannel
         self._response_waiters: dict[str, asyncio.Future] = {}
         self.redis: redis.Redis = None
         self._restart: bool = True

--- a/discord_extensions/admin.py
+++ b/discord_extensions/admin.py
@@ -3,46 +3,45 @@ import os
 
 import discord
 from discord.ext import commands
-from core.config import discord as config, settings
-
+from core.config import DiscordConfig, SettingsConfig
 
 class Admin(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
     @commands.command()
-    @commands.has_role(config.overrideRole)
+    @commands.has_role(DiscordConfig.overrideRole)
     async def notifications(self, ctx):
         await self.bot.mineflayer_bot.chat("/g notifications")
 
     @commands.command()
-    @commands.has_role(config.overrideRole)
+    @commands.has_role(DiscordConfig.overrideRole)
     async def toggleaccept(self, ctx):
-        if settings.autoaccept:
+        if SettingsConfig.autoaccept:
             embedVar = discord.Embed(description=":white_check_mark: Auto accepting guild invites is now ``off``!")
             await ctx.send(embed=embedVar)
-            settings.autoaccept = False
+            SettingsConfig.autoaccept = False
         else:
             embedVar = discord.Embed(description=":white_check_mark: Auto accepting guild invites is now ``on``!")
             await ctx.send(embed=embedVar)
-            settings.autoaccept = True
+            SettingsConfig.autoaccept = True
 
     @commands.command(aliases=['r'])
-    @commands.has_role(config.commandRole)
+    @commands.has_role(DiscordConfig.commandRole)
     async def relog(self, ctx):
         self.bot.mineflayer_bot.stop(True)
         embedVar = discord.Embed(color=0x1ABC9C).set_author(name="Restarting the bot...")
         await ctx.send(embed=embedVar)
 
     @commands.command(aliases=['o', 'over'])
-    @commands.has_role(config.overrideRole)
+    @commands.has_role(DiscordConfig.overrideRole)
     async def override(self, ctx, *, command):
         await self.bot.mineflayer_bot.chat("/" + command)
         embedVar = discord.Embed(color=0x1ABC9C).set_author(name=f"`/{command}` has been sent!")
         await ctx.send(embed=embedVar)
 
     @commands.command()
-    @commands.has_role(config.overrideRole)
+    @commands.has_role(DiscordConfig.overrideRole)
     async def update(self, ctx):
         embedVar = discord.Embed(color=0x1ABC9C).set_author(name="Updating the bot...")
         await ctx.send(embed=embedVar)
@@ -51,7 +50,7 @@ class Admin(commands.Cog):
         await asyncio.sleep(10)
 
     @commands.command()
-    @commands.has_role(config.overrideRole)
+    @commands.has_role(DiscordConfig.overrideRole)
     async def reload(self, ctx):
         embedVar = discord.Embed(color=0x1ABC9C).set_author(name="Reloading extensions...")
         msg = await ctx.send(embed=embedVar)

--- a/discord_extensions/bridge.py
+++ b/discord_extensions/bridge.py
@@ -1,6 +1,6 @@
 import discord
 from discord.ext import commands
-from core.config import discord as config
+from core.config import DiscordConfig
 
 
 class Bridge(commands.Cog):
@@ -8,7 +8,7 @@ class Bridge(commands.Cog):
         self.bot = bot
 
     @commands.command()
-    @commands.has_role(config.commandRole)
+    @commands.has_role(DiscordConfig.commandRole)
     async def invite(self, ctx, username):
         result = await self.bot.send_invite(username)
         if not result[0] and result[1] == "timeout":
@@ -19,33 +19,33 @@ class Bridge(commands.Cog):
             await ctx.send(embed=embedVar)
 
     @commands.command()
-    @commands.has_role(config.commandRole)
+    @commands.has_role(DiscordConfig.commandRole)
     async def kick(self, ctx, username, *, reason):
         await self.bot.mineflayer_bot.chat("/g kick " + username + " " + reason)
 
     @commands.command()
-    @commands.has_role(config.commandRole)
+    @commands.has_role(DiscordConfig.commandRole)
     async def promote(self, ctx, username):
         await self.bot.mineflayer_bot.chat("/g promote " + username)
 
     @commands.command()
-    @commands.has_role(config.commandRole)
+    @commands.has_role(DiscordConfig.commandRole)
     async def mute(self, ctx, username, time):
         await self.bot.mineflayer_bot.chat("/g mute " + username + " " + time)
         await self.bot.wait_for("message", check=lambda m: m.content == f"Successfully muted {username} for {time}.")
 
     @commands.command()
-    @commands.has_role(config.commandRole)
+    @commands.has_role(DiscordConfig.commandRole)
     async def unmute(self, ctx, username):
         await self.bot.mineflayer_bot.chat("/g unmute " + username)
 
     @commands.command()
-    @commands.has_role(config.commandRole)
+    @commands.has_role(DiscordConfig.commandRole)
     async def setrank(self, ctx, username, rank):
         await self.bot.mineflayer_bot.chat("/g setrank " + username + " " + rank)
 
     @commands.command()
-    @commands.has_role(config.commandRole)
+    @commands.has_role(DiscordConfig.commandRole)
     async def demote(self, ctx, username):
         await self.bot.mineflayer_bot.chat("/g demote " + username)
 

--- a/discord_extensions/bridge.py
+++ b/discord_extensions/bridge.py
@@ -32,6 +32,7 @@ class Bridge(commands.Cog):
     @commands.has_role(config.commandRole)
     async def mute(self, ctx, username, time):
         await self.bot.mineflayer_bot.chat("/g mute " + username + " " + time)
+        await self.bot.wait_for("message", check=lambda m: m.content == f"Successfully muted {username} for {time}.")
 
     @commands.command()
     @commands.has_role(config.commandRole)

--- a/discord_extensions/generic.py
+++ b/discord_extensions/generic.py
@@ -1,6 +1,6 @@
 import discord
 from discord.ext import commands
-from core.config import discord as config
+from core.config import DiscordConfig
 
 
 class Generic(commands.Cog):
@@ -16,26 +16,26 @@ class Generic(commands.Cog):
         )
         embed.add_field(
             name="Discord Commands",
-            value=f"``{config.prefix}invite <username>``: Invites the user to the guild\n"
-                  f"``{config.prefix}promote <username>``: Promotes the given user\n"
-                  f"``{config.prefix}demote <username>``: Demotes the given user\n"
-                  f"``{config.prefix}setrank <username> <rank>``: Sets the given user to a specific rank\n"
-                  f"``{config.prefix}kick <username> [reason]``: Kicks the given user\n"
-                  f"``{config.prefix}notifications``: Toggles join / leave notifications\n"
-                  f"``{config.prefix}online``: Shows the online members\n"
-                  f"``{config.prefix}override <command>``: Forces the bot to use a given command\n"
-                  f"``{config.prefix}toggleaccept``: Toggles auto accepting members joining the guild\n"
-                  f"``{config.prefix}mute <username> <time>`` - Mutes the user for a specific time\n"
-                  f"``{config.prefix}unmute <username>`` - Unmutes the user",
+            value=f"``{DiscordConfig.prefix}invite <username>``: Invites the user to the guild\n"
+                  f"``{DiscordConfig.prefix}promote <username>``: Promotes the given user\n"
+                  f"``{DiscordConfig.prefix}demote <username>``: Demotes the given user\n"
+                  f"``{DiscordConfig.prefix}setrank <username> <rank>``: Sets the given user to a specific rank\n"
+                  f"``{DiscordConfig.prefix}kick <username> [reason]``: Kicks the given user\n"
+                  f"``{DiscordConfig.prefix}notifications``: Toggles join / leave notifications\n"
+                  f"``{DiscordConfig.prefix}online``: Shows the online members\n"
+                  f"``{DiscordConfig.prefix}override <command>``: Forces the bot to use a given command\n"
+                  f"``{DiscordConfig.prefix}toggleaccept``: Toggles auto accepting members joining the guild\n"
+                  f"``{DiscordConfig.prefix}mute <username> <time>`` - Mutes the user for a specific time\n"
+                  f"``{DiscordConfig.prefix}unmute <username>`` - Unmutes the user",
             inline=False
         )
         embed.add_field(
             name="Info",
-            value=f"Prefix: ``{config.prefix}``\n"
-                  f"Guild Channel: <#{config.channel}>\n"
-                  f"Officer Channel: <#{config.officerChannel}>\n"
-                  f"Command Role: <@&{config.commandRole}>\n"
-                  f"Override Role: <@&{config.overrideRole}>\n"
+            value=f"Prefix: ``{DiscordConfig.prefix}``\n"
+                  f"Guild Channel: <#{DiscordConfig.channel}>\n"
+                  f"Officer Channel: <#{DiscordConfig.officerChannel}>\n"
+                  f"Command Role: <@&{DiscordConfig.commandRole}>\n"
+                  f"Override Role: <@&{DiscordConfig.overrideRole}>\n"
                   f"Version: ``1.0``",
             inline=False
         )

--- a/example.config.json
+++ b/example.config.json
@@ -14,17 +14,20 @@
         "overrideRole": "",
         "ownerId": "",
         "prefix": "!",
+        "webhookURL": "",
+        "officerWebhookURL": "",
         "debugWebhookURL": ""
     },
     "redis": {
-        "host": "redisIP",
+        "host": "",
         "port": 6379,
-        "password": "redisPassword",
-        "clientName": "clientName",
-        "recieveChannel": "bridge-bot",
-        "sendChannel": "bridge-bot-control"
+        "password": "",
+        "clientName": "",
+        "recieveChannel": "",
+        "sendChannel": ""
     },
     "settings": {
-        "autoaccept": false
+        "autoaccept": false,
+        "extensions": []
     }
 }

--- a/extensions/mute_sync.py
+++ b/extensions/mute_sync.py
@@ -1,0 +1,175 @@
+"""
+Mute syncing extension
+
+Uses the SkyKings and Hypixel APIs.
+"""
+import asyncio
+import datetime
+
+import aiohttp
+import discord
+from discord.ext import commands
+from core.config import DiscordConfig, ExtensionConfig, ConfigKey
+
+
+class MuteSyncConfig(ExtensionConfig, base_key="mute_sync"):
+    mute_role: int = ConfigKey(int)
+    hypixel_api_key: str = ConfigKey(str)
+    skykings_api_key: str = ConfigKey(str)
+
+
+class MuteSync(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        self.mutes = {}  # (discord id, uuid): datetime
+        self._sess: aiohttp.ClientSession | None = None
+        self.mute_task: tuple[asyncio.Task, datetime] | None = None
+
+    async def cog_load(self) -> None:
+        await self.sync_mutes()
+
+    async def cog_unload(self) -> None:
+        if self._sess is not None:
+            await self._sess.close()
+        if self.mute_task is not None:
+            self.mute_task[0].cancel()
+        try:
+            await self.mute_task[0]
+        except asyncio.CancelledError:
+            pass
+        self.mutes = {}
+
+    async def get_session(self):
+        if self._sess is None:
+            self._sess = aiohttp.ClientSession()
+        return self._sess
+
+    async def get_uuid(self, username):
+        session = await self.get_session()
+        async with session.get(f"https://api.mojang.com/users/profiles/minecraft/{username}") as resp:
+            if resp.status != 200:
+                resp.raise_for_status()
+            data = await resp.json()
+            return data["id"]
+
+    async def get_discord_user(self, uuid):
+        session = await self.get_session()
+        async with session.get(
+                f"https://skykings.net/api/user?uuid={uuid}",
+                headers={"Authorization": MuteSyncConfig.skykings_api_key},
+        ) as resp:
+            if resp.status == 404:
+                return None
+            if resp.status != 200:
+                resp.raise_for_status()
+            data = await resp.json()
+            return data["discord_id"]
+
+    async def fill_guild_mutes(self):
+        bot_uuid = await self.get_uuid(self.bot.mineflayer_bot.bot.username)
+        session = await self.get_session()
+        async with session.get(
+                f"https://api.hypixel.net/guild?player={bot_uuid}"
+        ) as resp:
+            if resp.status != 200:
+                resp.raise_for_status()
+            data = await resp.json()
+            guild = data["guild"]
+            for member in guild["members"]:
+                if member.get("mutedTill") is not None:
+                    uuid = member["uuid"]
+                    discord_id = await self.get_discord_user(uuid)
+                    self.mutes[(discord_id, uuid)] = datetime.datetime.fromtimestamp(member["mutedTill"] / 1000)
+
+    async def sync_mutes(self):
+        await self.fill_guild_mutes()
+        for (discord_id, uuid), expiry in self.mutes.items():
+            if expiry < datetime.datetime.now():
+                if discord_id is None:
+                    self.mutes.pop((discord_id, uuid))
+                    continue
+                # use bridge channel to get guild
+                guild = self.bot.get_channel(DiscordConfig.channel)
+                member = guild.get_member(discord_id)
+                if member is None:
+                    continue
+                role = guild.get_role(MuteSyncConfig.mute_role)
+                await member.add_roles(role)
+            elif discord_id is not None:
+                guild = self.bot.get_channel(DiscordConfig.channel)
+                member = guild.get_member(discord_id)
+                if member is None:
+                    self.mutes.pop((discord_id, uuid))
+                    continue
+                role = guild.get_role(MuteSyncConfig.mute_role)
+                await member.remove_roles(role)
+
+    async def process_new_mute(self, player: str, duration: datetime.timedelta):
+        uuid = await self.get_uuid(player)
+        discord_id = await self.get_discord_user(uuid)
+        if discord_id is None:
+            return
+        guild = self.bot.get_channel(DiscordConfig.channel)
+        member = guild.get_member(discord_id)
+        if member is None:
+            return
+        role = guild.get_role(MuteSyncConfig.mute_role)
+        await member.add_roles(role)
+        self.mutes[(discord_id, uuid)] = datetime.datetime.now() + duration
+        await self.update_mute_task()
+
+    async def process_new_unmute(self, player: str):
+        uuid = await self.get_uuid(player)
+        # remove mute from self.mutes
+        [self.mutes.pop((discord_id, uuid)) for discord_id, _uuid in self.mutes if _uuid == uuid]
+        discord_id = await self.get_discord_user(uuid)
+        if discord_id is None:
+            return
+        guild = self.bot.get_channel(DiscordConfig.channel)
+        member = guild.get_member(discord_id)
+        if member is None:
+            return
+        role = guild.get_role(MuteSyncConfig.mute_role)
+        await member.remove_roles(role)
+        await self.update_mute_task()
+
+    async def _mute_task(self, identifier, expiry):
+        await asyncio.sleep((expiry - datetime.datetime.now()).total_seconds())
+        self.mute_task = None
+        guild = self.bot.get_channel(DiscordConfig.channel)
+        member = guild.get_member(identifier)
+        if member is None:
+            return
+        role = guild.get_role(MuteSyncConfig.mute_role)
+        await member.remove_roles(role)
+        self.mutes.pop(identifier)
+        # noinspection PyAsyncCall
+        asyncio.create_task(self.update_mute_task())
+
+    async def update_mute_task(self):
+        # take the soonest to expire mute
+        [identifier, expiry] = min(self.mutes.items(), key=lambda x: x[1])
+        if self.mute_task is not None:
+            if expiry < self.mute_task[1]:
+                self.mute_task[0].cancel()
+                self.mute_task = (asyncio.create_task(self._mute_task(identifier, expiry)), expiry)
+        else:
+            self.mute_task = (asyncio.create_task(self._mute_task(identifier, expiry)), expiry)
+
+    @commands.Cog.listener()
+    async def on_hypixel_guild_member_muted(self, _, player, duration):
+        # hypixel does not allow specific durations (e.g. 1d 1h, only 1h or 1d)
+        if duration[-1] == "d":
+            delta = datetime.timedelta(days=int(duration[:-1]))
+        elif duration[-1] == "h":
+            delta = datetime.timedelta(hours=int(duration[:-1]))
+        elif duration[-1] == "m":
+            delta = datetime.timedelta(minutes=int(duration[:-1]))
+        else:
+            raise Exception("Invalid duration")
+        await self.process_new_mute(player, delta)
+
+    @commands.Cog.listener()
+    async def on_hypixel_guild_member_unmuted(self, _, player):
+        # hypixel does not allow specific durations (e.g. 1d 1h, only 1h or 1d)
+        await self.process_new_unmute(player)

--- a/extensions/mute_sync.py
+++ b/extensions/mute_sync.py
@@ -24,9 +24,7 @@ class MuteSync(commands.Cog):
         self.mutes = {}  # (discord id, uuid): datetime
         self._sess: aiohttp.ClientSession | None = None
         self.mute_task: tuple[asyncio.Task, datetime] | None = None
-
-    async def cog_load(self) -> None:
-        await self.sync_mutes()
+        self._syncing = False
 
     async def cog_unload(self) -> None:
         if self._sess is not None:
@@ -63,13 +61,14 @@ class MuteSync(commands.Cog):
             if resp.status != 200:
                 resp.raise_for_status()
             data = await resp.json()
-            return data["discord_id"]
+            return int(data["user"])
 
     async def fill_guild_mutes(self):
         bot_uuid = await self.get_uuid(self.bot.mineflayer_bot.bot.username)
         session = await self.get_session()
         async with session.get(
-                f"https://api.hypixel.net/guild?player={bot_uuid}"
+                f"https://api.hypixel.net/guild?player={bot_uuid}",
+                headers={"API-Key": MuteSyncConfig.hypixel_api_key}
         ) as resp:
             if resp.status != 200:
                 resp.raise_for_status()
@@ -79,75 +78,86 @@ class MuteSync(commands.Cog):
                 if member.get("mutedTill") is not None:
                     uuid = member["uuid"]
                     discord_id = await self.get_discord_user(uuid)
-                    self.mutes[(discord_id, uuid)] = datetime.datetime.fromtimestamp(member["mutedTill"] / 1000)
+                    exp = datetime.datetime.fromtimestamp(member["mutedTill"] / 1000)
+                    if exp > datetime.datetime.now():
+                        self.mutes[(discord_id, uuid)] = exp
 
     async def sync_mutes(self):
         await self.fill_guild_mutes()
-        for (discord_id, uuid), expiry in self.mutes.items():
-            if expiry < datetime.datetime.now():
-                if discord_id is None:
-                    self.mutes.pop((discord_id, uuid))
-                    continue
+        for (discord_id, uuid), expiry in dict(self.mutes).items():
+            if expiry > datetime.datetime.now():
                 # use bridge channel to get guild
-                guild = self.bot.get_channel(DiscordConfig.channel)
+                guild = self.bot.get_channel(DiscordConfig.channel).guild
                 member = guild.get_member(discord_id)
                 if member is None:
                     continue
                 role = guild.get_role(MuteSyncConfig.mute_role)
-                await member.add_roles(role)
+                await member.add_roles(role, reason="SYNC: User has an active guild mute")
             elif discord_id is not None:
-                guild = self.bot.get_channel(DiscordConfig.channel)
+                guild = self.bot.get_channel(DiscordConfig.channel).guild
                 member = guild.get_member(discord_id)
                 if member is None:
                     self.mutes.pop((discord_id, uuid))
                     continue
                 role = guild.get_role(MuteSyncConfig.mute_role)
-                await member.remove_roles(role)
+                await member.remove_roles(role, reason="SYNC: User has no active guild mute")
+                self.mutes.pop((discord_id, uuid))
 
     async def process_new_mute(self, player: str, duration: datetime.timedelta):
         uuid = await self.get_uuid(player)
         discord_id = await self.get_discord_user(uuid)
         if discord_id is None:
             return
-        guild = self.bot.get_channel(DiscordConfig.channel)
+        guild = self.bot.get_channel(DiscordConfig.channel).guild
         member = guild.get_member(discord_id)
         if member is None:
             return
         role = guild.get_role(MuteSyncConfig.mute_role)
-        await member.add_roles(role)
+        await member.add_roles(role, reason="User has been guild muted")
         self.mutes[(discord_id, uuid)] = datetime.datetime.now() + duration
         await self.update_mute_task()
 
     async def process_new_unmute(self, player: str):
         uuid = await self.get_uuid(player)
         # remove mute from self.mutes
-        [self.mutes.pop((discord_id, uuid)) for discord_id, _uuid in self.mutes if _uuid == uuid]
-        discord_id = await self.get_discord_user(uuid)
+        val = [(discord_id, uuid, self.mutes.pop((discord_id, uuid))) for discord_id, _uuid in dict(self.mutes) if
+               _uuid == uuid][0]
+        discord_id, uuid, exp = val
         if discord_id is None:
-            return
-        guild = self.bot.get_channel(DiscordConfig.channel)
+            discord_id = await self.get_discord_user(uuid)
+            if discord_id is None:
+                return
+        guild = self.bot.get_channel(DiscordConfig.channel).guild
         member = guild.get_member(discord_id)
         if member is None:
             return
         role = guild.get_role(MuteSyncConfig.mute_role)
-        await member.remove_roles(role)
+        await member.remove_roles(role, reason="User has been guild unmuted")
         await self.update_mute_task()
 
     async def _mute_task(self, identifier, expiry):
-        await asyncio.sleep((expiry - datetime.datetime.now()).total_seconds())
-        self.mute_task = None
-        guild = self.bot.get_channel(DiscordConfig.channel)
-        member = guild.get_member(identifier)
-        if member is None:
-            return
-        role = guild.get_role(MuteSyncConfig.mute_role)
-        await member.remove_roles(role)
-        self.mutes.pop(identifier)
-        # noinspection PyAsyncCall
-        asyncio.create_task(self.update_mute_task())
+        try:
+            await asyncio.sleep((expiry - datetime.datetime.now()).total_seconds())
+            self.mute_task = None
+            guild = self.bot.get_channel(DiscordConfig.channel).guild
+            member = guild.get_member(identifier[0])
+            if member is None:
+                return
+            role = guild.get_role(MuteSyncConfig.mute_role)
+            await member.remove_roles(role, reason="User's guild mute has expired")
+            self.mutes.pop(identifier)
+        except asyncio.CancelledError:
+            pass
+        except Exception as e:
+            await self.bot.on_error("mute_task")
 
     async def update_mute_task(self):
         # take the soonest to expire mute
+        if not self.mutes:
+            if self.mute_task is not None:
+                self.mute_task[0].cancel()
+                self.mute_task = None
+            return
         [identifier, expiry] = min(self.mutes.items(), key=lambda x: x[1])
         if self.mute_task is not None:
             if expiry < self.mute_task[1]:
@@ -155,6 +165,7 @@ class MuteSync(commands.Cog):
                 self.mute_task = (asyncio.create_task(self._mute_task(identifier, expiry)), expiry)
         else:
             self.mute_task = (asyncio.create_task(self._mute_task(identifier, expiry)), expiry)
+        self.mute_task[0].add_done_callback(lambda _: asyncio.create_task(self.update_mute_task()))
 
     @commands.Cog.listener()
     async def on_hypixel_guild_member_muted(self, _, player, duration):
@@ -173,3 +184,63 @@ class MuteSync(commands.Cog):
     async def on_hypixel_guild_member_unmuted(self, _, player):
         # hypixel does not allow specific durations (e.g. 1d 1h, only 1h or 1d)
         await self.process_new_unmute(player)
+
+    @commands.Cog.listener()
+    async def on_minecraft_ready(self):
+        await self.bot.wait_until_ready()
+        guild = self.bot.get_channel(DiscordConfig.channel).guild
+        await guild.chunk(cache=True)
+        if not self._syncing:
+            self._syncing = True
+            print("MuteSync > Syncing mutes...")
+            await self.sync_mutes()
+            # go through role members and check if they are muted
+            role = guild.get_role(MuteSyncConfig.mute_role)
+            for member in role.members:
+                data = [(k, v) for k, v in dict(self.mutes).items() if k[0] == member.id]
+                if not data:
+                    await member.remove_roles(role, reason="STARTUP: User has no active guild mute")
+                else:
+                    if data[0][1] < datetime.datetime.now():
+                        await member.remove_roles(role, reason="STARTUP: User has no active guild mute")
+            print("MuteSync > Mutes synced!")
+            self._syncing = False
+
+    @commands.Cog.listener()
+    async def on_member_join(self, member):
+        if member.id is None:
+            return
+        # find the mute
+        for (discord_id, uuid), expiry in dict(self.mutes).items():
+            if discord_id == member.id:
+                if expiry > datetime.datetime.now():
+                    role = member.guild.get_role(MuteSyncConfig.mute_role)
+                    await member.add_roles(role, reason="JOIN: User has an active guild mute")
+                    break
+
+    @commands.Cog.listener()
+    async def on_member_update(self, before, after):
+        if before.roles == after.roles:
+            return
+        if (MuteSyncConfig.mute_role in [role.id for role in before.roles] or
+                MuteSyncConfig.mute_role in [role.id for role in after.roles]):
+            return
+        # check if mute is still valid
+        valid = False
+        for (discord_id, uuid), expiry in dict(self.mutes).items():
+            if discord_id == after.id:
+                if expiry > datetime.datetime.now():
+                    valid = True
+                    if MuteSyncConfig.mute_role not in [role.id for role in after.roles]:
+                        role = after.guild.get_role(MuteSyncConfig.mute_role)
+                        await after.add_roles(role, reason="UPDATE: User has an active guild mute")
+                        break
+        if not valid:
+            if MuteSyncConfig.mute_role in [role.id for role in after.roles]:
+                role = after.guild.get_role(MuteSyncConfig.mute_role)
+                await after.remove_roles(role, reason="UPDATE: User has no active guild mute")
+
+
+async def setup(bot):
+    bot.get_intents().members = True
+    await bot.add_cog(MuteSync(bot))

--- a/extensions/test.py
+++ b/extensions/test.py
@@ -1,2 +1,0 @@
-async def setup(bot):
-    print("Cog setup!")

--- a/extensions/test.py
+++ b/extensions/test.py
@@ -1,0 +1,2 @@
+def setup(bot):
+    print("Cog setup!")

--- a/extensions/test.py
+++ b/extensions/test.py
@@ -1,2 +1,2 @@
-def setup(bot):
+async def setup(bot):
     print("Cog setup!")

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 from core.discord_bot import DiscordBridgeBot
 import asyncio
-from core.config import discord as config
+from core.config import DiscordConfig, SettingsConfig
 
 bot = DiscordBridgeBot()
 
@@ -10,7 +10,11 @@ async def main():
         await bot.load_extension("discord_extensions.admin")
         await bot.load_extension("discord_extensions.bridge")
         await bot.load_extension("discord_extensions.generic")
-        await bot.start(config.token)
+        print(SettingsConfig.extensions, type(SettingsConfig.extensions))
+        for extension in SettingsConfig.extensions:
+            await bot.load_extension(extension)
+        print("Extensions loaded!")
+        await bot.start(DiscordConfig.token)
 
 
 asyncio.run(main())

--- a/main.py
+++ b/main.py
@@ -10,10 +10,12 @@ async def main():
         await bot.load_extension("discord_extensions.admin")
         await bot.load_extension("discord_extensions.bridge")
         await bot.load_extension("discord_extensions.generic")
-        print(SettingsConfig.extensions, type(SettingsConfig.extensions))
-        for extension in SettingsConfig.extensions:
-            await bot.load_extension(extension)
-        print("Extensions loaded!")
+        if SettingsConfig.extensions:
+            print(f"Ext > Loading {len(SettingsConfig.extensions)} extensions...")
+            for extension in SettingsConfig.extensions:
+                await bot.load_extension(extension, package="extensions" if extension.startswith(".") else None)
+                print(f"Ext > {extension} loaded!")
+            print("Ext > Extensions loaded!")
         await bot.start(DiscordConfig.token)
 
 


### PR DESCRIPTION
Adds a way to create your own extensions to add into the bridge bot- piggybacking off of discord.py's extension framework.

Extensions will be able to *extend* the bridge bot, adding additional functionality, set with their own configuration.

Also adds an extension for syncing a Discord mute role with guild mutes using the SkyKings API (Incomplete)

### TODO
- [x] Write guild mute syncing extension
- [x] Write guide for making bridge bot extensions